### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/Task.js
+++ b/lib/Task.js
@@ -1,6 +1,6 @@
 "use strict";
 var ChannelManager_1 = require('./ChannelManager');
-var uuid = require("node-uuid");
+var uuid = require("uuid");
 var _ = require("lodash");
 var EXCHANGE_PREFIX = "nimbus:jobs:";
 var EXCHANGE_OPTIONS = { durable: true, autoDelete: false };

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "jit-grunt": "^0.9.1",
     "just.randomstring": "^0.1.1",
     "lodash": "^3.10.1",
-    "node-uuid": "^1.4.3",
+    "source-map-support": "^0.3.3",
     "typescript": "^1.8.7",
-    "source-map-support": "^0.3.3"
+    "uuid": "^3.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -2,7 +2,7 @@ import { channelManager } from './ChannelManager'
 import { TaskManager } from "./TaskManager"
 import { Channel } from "amqplib/callback_api"
 
-import uuid = require("node-uuid")
+import uuid = require("uuid")
 import _ = require("lodash")
 
 const EXCHANGE_PREFIX = "nimbus:jobs:";

--- a/typings/node-uuid/node-uuid-cjs.d.ts
+++ b/typings/node-uuid/node-uuid-cjs.d.ts
@@ -9,7 +9,7 @@
  * Expose as CommonJS module
  * For use in node environment or browser environment (using webpack or other module loaders)
  */
-declare module "node-uuid" {
+declare module "uuid" {
     var uuid: __NodeUUID.UUID;
     export = uuid;
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.